### PR TITLE
fix(gen-client): Renamed from narrowcasting to Aurora

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint-fix": "eslint ./src --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore --fix",
     "format": "prettier --ignore-path .gitignore --check ./src/",
     "format-fix": "prettier --ignore-path .gitignore --write ./src/",
-    "gen-client": "openapi --input ../narrowcasting-core/build/swagger.json --output src/api/",
+    "gen-client": "openapi --input ../aurora-core/build/swagger.json --output src/api/",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
Quick fix to rename the folder for gen-client to aurora to narrowcasting, as the repository is now called aurora :)