### PR TITLE
feat(spotify): add Spotify settings view

### DIFF
--- a/src/components/audio/SpotifyCallbackDialog.vue
+++ b/src/components/audio/SpotifyCallbackDialog.vue
@@ -1,0 +1,51 @@
+<template>
+  <Dialog class="w-96" :closable="false" header="Processing login..." modal :visible="open">
+    <template #default>
+      <div class="flex flex-col items-center justify-center my-2">
+        <ProgressSpinner v-if="loading" />
+      </div>
+      <Message v-if="!loading && errorMessage" severity="error"> Login failed: {{ errorMessage }} </Message>
+      <Message v-else-if="!loading" severity="success">
+        Successfully logged in user {{ store.currentSpotifyProfile?.display_name }}
+      </Message>
+    </template>
+    <template #footer>
+      <Button :disabled="loading" label="Close" @click="handleClose()" />
+    </template>
+  </Dialog>
+</template>
+
+<script lang="ts" setup>
+import { onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useSpotifyStore } from '@/stores/spotify.store';
+
+const store = useSpotifyStore();
+const route = useRoute();
+
+const open = ref<boolean>(false);
+const loading = ref<boolean>(true);
+const errorMessage = ref<string | undefined>();
+
+const handleClose = () => {
+  if (loading.value) return;
+
+  open.value = false;
+};
+
+onMounted(async () => {
+  if (route.path === '/spotify/callback') {
+    open.value = true;
+    const state = Array.isArray(route.query.state) ? route.query.state.join(',') : route.query.state;
+    const code = Array.isArray(route.query.code) ? route.query.code.join(',') : route.query.code;
+    const error = Array.isArray(route.query.error) ? route.query.error.join(',') : route.query.error;
+    const res = await store.loginCallback(state ?? '', code ?? undefined, error ?? undefined);
+    if (!res.success) {
+      errorMessage.value = res.error;
+    }
+    loading.value = false;
+  }
+});
+</script>
+
+<style scoped></style>

--- a/src/components/audio/SpotifyCurrentlyPlaying.vue
+++ b/src/components/audio/SpotifyCurrentlyPlaying.vue
@@ -11,7 +11,6 @@
       <div class="flex flex-col gap-1 h-100 justify-content-center">
         <span class="text-xl">{{ store.currentlyPlaying?.title }}</span>
         <span class="text-lg">{{ store.currentlyPlaying?.artists.join(', ') }}</span>
-        <span class="material-icons">arrow_drop_down</span>
       </div>
     </div>
     <div v-else>

--- a/src/components/audio/SpotifyCurrentlyPlaying.vue
+++ b/src/components/audio/SpotifyCurrentlyPlaying.vue
@@ -1,35 +1,29 @@
 <template>
-  <Panel class="w-full">
-    <template #header>
-      <div class="p-panel-title uppercase">
-        <i class="pi pi-headphones mr-1 text-xl" />
-        Currently Playing
+  <AppContainer icon="pi-headphones" title="Currently playing">
+    <div v-if="store.currentlyPlaying != null" class="flex flex-row items-center gap-4">
+      <div class="w-32">
+        <img
+          :alt="store.currentlyPlaying.cover"
+          :src="store.currentlyPlaying.cover"
+          :style="{ width: '100%', borderRadius: '5px' }"
+        />
       </div>
-    </template>
-    <template #default>
-      <div v-if="store.currentlyPlaying != null" class="flex gap-2">
-        <div :style="{ width: '60px' }">
-          <img
-            :alt="store.currentlyPlaying.cover"
-            :src="store.currentlyPlaying.cover"
-            :style="{ width: '100%', borderRadius: '5px' }"
-          />
-        </div>
-        <div class="flex flex-column gap-1 h-100 justify-content-center">
-          <span>{{ store.currentlyPlaying?.title }}</span>
-          <span class="text-sm">{{ store.currentlyPlaying?.artists.join(', ') }}</span>
-        </div>
+      <div class="flex flex-col gap-1 h-100 justify-content-center">
+        <span class="text-xl">{{ store.currentlyPlaying?.title }}</span>
+        <span class="text-lg">{{ store.currentlyPlaying?.artists.join(', ') }}</span>
+        <span class="material-icons">arrow_drop_down</span>
       </div>
-      <div v-else>
-        <span class="font-italic">Nothing playing on Spotify at the moment</span>
-      </div>
-    </template>
-  </Panel>
+    </div>
+    <div v-else>
+      <span class="font-italic">Nothing playing on Spotify at the moment</span>
+    </div>
+  </AppContainer>
 </template>
 
 <script setup lang="ts">
 import { onUnmounted } from 'vue';
 import { useCurrentlyPlayingStore } from '@/stores/socket/currently-playing.store';
+import AppContainer from '@/layout/AppContainer.vue';
 
 const store = useCurrentlyPlayingStore();
 store.init();

--- a/src/components/audio/SpotifyUserDeleteButton.vue
+++ b/src/components/audio/SpotifyUserDeleteButton.vue
@@ -1,0 +1,38 @@
+<template>
+  <Button icon="pi pi-trash" severity="danger" size="small" @click="confirmRef?.confirmDialog" />
+  <ConfirmWrapper
+    ref="confirmRef"
+    delete
+    :loading="loading"
+    :message="confirmMessage"
+    :on-accept="
+      () => {
+        loading = true;
+        store.deleteSpotifyUser(user.id).finally(() => {
+          loading = false;
+        });
+      }
+    "
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useSpotifyStore } from '@/stores/spotify.store';
+import type { SpotifyUserResponse } from '@/api';
+import ConfirmWrapper from '@/components/prime/ConfirmWrapper.vue';
+
+const store = useSpotifyStore();
+
+const props = defineProps<{
+  user: SpotifyUserResponse;
+}>();
+
+const confirmRef = ref();
+const loading = ref<boolean>(false);
+const confirmMessage = computed<string>(() => {
+  return `Are you sure you want to delete Spotify user "${props.user.name}"?`;
+});
+</script>
+
+<style scoped></style>

--- a/src/components/audio/SpotifyUserSwitchButton.vue
+++ b/src/components/audio/SpotifyUserSwitchButton.vue
@@ -1,0 +1,33 @@
+<template>
+  <Button
+    :disabled="user.active || loading"
+    icon="pi pi-user-plus"
+    :loading="loading"
+    severity="success"
+    size="small"
+    :title="user.active ? 'User already active' : 'Make user active'"
+    @click="handleClick()"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import type { SpotifyUserResponse } from '@/api';
+import { useSpotifyStore } from '@/stores/spotify.store';
+
+const store = useSpotifyStore();
+
+const props = defineProps<{
+  user: SpotifyUserResponse;
+}>();
+
+const loading = ref<boolean>(false);
+
+const handleClick = async () => {
+  loading.value = true;
+  await store.makeUserActive(props.user);
+  loading.value = false;
+};
+</script>
+
+<style scoped></style>

--- a/src/components/prime/ConfirmWrapper.vue
+++ b/src/components/prime/ConfirmWrapper.vue
@@ -1,3 +1,7 @@
+<template>
+  <span />
+</template>
+
 <script setup lang="ts">
 import { useConfirm } from 'primevue/useconfirm';
 

--- a/src/layout/AppMenu.vue
+++ b/src/layout/AppMenu.vue
@@ -32,6 +32,7 @@ const model = computed<MenuItem[]>(() => {
 
   const showSettings = authStore.isInSecurityGroup('serverSettings', 'privileged');
   const showTimedEvents = authStore.isInSecurityGroup('timedEvents', 'privileged');
+  const showSpotifySettings = authStore.isInSecurityGroup('spotify', 'privileged');
 
   const serverSettingsStore = useServerSettingsStore();
 
@@ -76,11 +77,12 @@ const model = computed<MenuItem[]>(() => {
         showCenturion && { label: 'Centurion', icon: 'pi pi-fw pi-crown', to: '/modes/centurion' },
       ].filter(Boolean),
     },
-    (showSettings || showTimedEvents) && {
+    (showSettings || showTimedEvents || showSpotifySettings) && {
       label: 'Settings',
       items: [
         showSettings && { label: 'Server Settings', icon: 'pi pi-fw pi-cog', to: '/settings' },
         showTimedEvents && { label: 'Timed Events', icon: 'pi pi-fw pi-calendar-clock', to: '/timed-events' },
+        showSpotifySettings && { label: 'Spotify Settings', icon: 'pi pi-headphones', to: '/spotify' },
       ],
     },
   ].filter(Boolean) as MenuItem[];

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,7 @@ app.component('TabPanel', TabPanel);
 app.component('ScrollPanel', ScrollPanel);
 app.component('FileUpload', FileUpload);
 app.component('Spinner', ProgressSpinner);
+app.component('ProgressSpinner', ProgressSpinner);
 app.component('ProgressBar', ProgressBar);
 app.component('Slider', Slider);
 app.component('Toast', Toast);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -138,6 +138,22 @@ const router = createRouter({
           },
         },
         {
+          path: '/spotify',
+          component: () => import('@/views/Base/SpotifySettingsView.vue'),
+          name: 'SpotifySettings',
+          meta: {
+            securityGroup: 'spotify',
+            securitySection: 'privileged',
+          },
+          children: [
+            {
+              path: 'callback',
+              component: () => import('@/views/Base/SpotifySettingsView.vue'),
+              name: 'SpotifyLoginCallback',
+            },
+          ],
+        },
+        {
           path: '/audit',
           component: () => import('@/views/Audit/AuditLogsView.vue'),
           name: 'AuditLogs',

--- a/src/stores/spotify.store.ts
+++ b/src/stores/spotify.store.ts
@@ -1,0 +1,55 @@
+import { defineStore } from 'pinia';
+import {
+  deleteSpotifyUser,
+  getAllSpotifyUsers,
+  spotifyLoginCallback,
+  type SpotifyUserProfile,
+  type SpotifyUserResponse,
+} from '@/api';
+
+interface SpotifyStore {
+  loading: boolean;
+  spotifyUsers: SpotifyUserResponse[];
+  currentSpotifyProfile: SpotifyUserProfile | undefined;
+}
+
+export const useSpotifyStore = defineStore('spotify', {
+  state: (): SpotifyStore => ({
+    loading: true,
+    spotifyUsers: [],
+    currentSpotifyProfile: undefined,
+  }),
+  actions: {
+    async init() {
+      const res = await getAllSpotifyUsers();
+      if (res.response.ok && res.data) {
+        this.spotifyUsers = res.data;
+      }
+      this.loading = false;
+    },
+    async deleteSpotifyUser(id: number) {
+      const res = await deleteSpotifyUser({ path: { id } });
+      if (res.response.ok) {
+        const index = this.spotifyUsers.findIndex((u) => u.id === id);
+        if (index >= 0) {
+          this.spotifyUsers.splice(index, 1);
+        }
+      }
+    },
+    async loginCallback(state: string, code?: string, error?: string) {
+      const res = await spotifyLoginCallback({ query: { state, code, error } });
+      if (!res.response.ok) {
+        return {
+          success: false,
+          error: res.error,
+        };
+      } else {
+        this.currentSpotifyProfile = res.data;
+        return {
+          success: true,
+          error: '',
+        };
+      }
+    },
+  },
+});

--- a/src/views/Base/SpotifySettingsView.vue
+++ b/src/views/Base/SpotifySettingsView.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
+    <AppContainer icon="pi-users" title="Spotify Settings">
+      <template #header>
+        <Button
+          as="a"
+          href="/api/spotify/login"
+          icon="pi pi-plus"
+          label="Add user"
+          severity="secondary"
+          variant="outlined"
+        />
+      </template>
+      <div class="flex flex-col gap-3">
+        <DataTable data-key="id" :loading="store.loading" selection="2" show-headers :value="store.spotifyUsers">
+          <Column class="w-1">
+            <template #body="slotProps">
+              <i v-if="slotProps.data.active" class="pi pi-arrow-right"></i>
+            </template>
+          </Column>
+          <Column field="name" header="Name" />
+          <Column>
+            <template #body="slotProps">
+              <div class="flex justify-end gap-2">
+                <Button
+                  :disabled="slotProps.data.active"
+                  icon="pi pi-user-plus"
+                  severity="success"
+                  size="small"
+                  :title="slotProps.data.active ? 'User already active' : 'Make user active'"
+                />
+                <SpotifyUserDeleteButton :user="slotProps.data" />
+              </div>
+            </template>
+          </Column>
+        </DataTable>
+      </div>
+    </AppContainer>
+    <SpotifyCurrentlyPlaying />
+  </div>
+  <SpotifyCallbackDialog />
+</template>
+
+<script setup lang="ts">
+import AppContainer from '@/layout/AppContainer.vue';
+import SpotifyCurrentlyPlaying from '@/components/audio/SpotifyCurrentlyPlaying.vue';
+import { useSpotifyStore } from '@/stores/spotify.store';
+import SpotifyCallbackDialog from '@/components/audio/SpotifyCallbackDialog.vue';
+import SpotifyUserDeleteButton from '@/components/audio/SpotifyUserDeleteButton.vue';
+
+const store = useSpotifyStore();
+store.init();
+</script>
+
+<style scoped></style>

--- a/src/views/Base/SpotifySettingsView.vue
+++ b/src/views/Base/SpotifySettingsView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
-    <AppContainer icon="pi-users" title="Spotify Settings">
+    <AppContainer icon="pi-users" title="Spotify Users">
       <template #header>
         <Button
           as="a"
@@ -22,13 +22,7 @@
           <Column>
             <template #body="slotProps">
               <div class="flex justify-end gap-2">
-                <Button
-                  :disabled="slotProps.data.active"
-                  icon="pi pi-user-plus"
-                  severity="success"
-                  size="small"
-                  :title="slotProps.data.active ? 'User already active' : 'Make user active'"
-                />
+                <SpotifyUserSwitchButton :user="slotProps.data" />
                 <SpotifyUserDeleteButton :user="slotProps.data" />
               </div>
             </template>
@@ -47,6 +41,7 @@ import SpotifyCurrentlyPlaying from '@/components/audio/SpotifyCurrentlyPlaying.
 import { useSpotifyStore } from '@/stores/spotify.store';
 import SpotifyCallbackDialog from '@/components/audio/SpotifyCallbackDialog.vue';
 import SpotifyUserDeleteButton from '@/components/audio/SpotifyUserDeleteButton.vue';
+import SpotifyUserSwitchButton from '@/components/audio/SpotifyUserSwitchButton.vue';
 
 const store = useSpotifyStore();
 store.init();

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -8,19 +8,20 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        api: 'modern-compiler'
-      }
-    }
+        api: 'modern-compiler',
+      },
+    },
   },
   plugins: [vue()],
   server: {
     port: 8080,
+    host: true,
     proxy: {
       '/api': {
         target: 'http://localhost:3000',
         changeOrigin: true,
         secure: false,
-        ws: true
+        ws: true,
       },
       '/socket.io': {
         target: 'ws://localhost:3000',
@@ -36,24 +37,24 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
-    }
+    },
   },
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
-    }
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
   },
   build: {
     target: 'ESNext',
     rollupOptions: {
-      output:{
+      output: {
         manualChunks(id) {
           if (id.includes('node_modules')) {
             return id.toString().split('node_modules/')[1].split('/')[0].toString();
           }
-        }
-      }
+        },
+      },
     },
-    chunkSizeWarningLimit: 750
-  }
+    chunkSizeWarningLimit: 750,
+  },
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds a new view to manage Spotify within Aurora. It includes the following features:
- Listing all Spotify accounts that are logged in to Aurora.
- Show the currently active Spotify user.
- Implement the Spotify authentication flow to log in users via the backoffice.
- Log out any Spotify users.
- Show the currently playing track, if any (does not have to be on Spotify, as it can for example also be Centurion).

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Depends on https://github.com/GEWIS/aurora-core/pull/50.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_