### PR TITLE
feat(centurion): add start timestamp to go to the beginning of the intro

### DIFF
--- a/src/components/modes/centurion/TapeTimeline.vue
+++ b/src/components/modes/centurion/TapeTimeline.vue
@@ -1,5 +1,5 @@
 <template>
-  <Menu class="!border-none columns-1 sm:columns-2" :model="timelineItems as Array<MenuItem>">
+  <Menu class="!border-none columns-1 sm:columns-2" :model="timelineItems">
     <template #item="{ item: event, props: menuProps }">
       <a class="flex justify-between" v-bind="menuProps.action">
         <div class="flex gap-4">
@@ -7,12 +7,12 @@
             ><b>{{ event.timestamp }}</b></span
           >
           <div class="flex gap-2 align-middle">
-            <div v-if="Array.isArray(event.label)">
+            <div v-if="'songs' in event">
               <div class="flex flex-col gap-4">
                 <span v-if="event.icon" :class="event.icon + ' mr-1'" />
-                <div v-for="label in event.label" :key="label" class="flex flex-col gap-2">
-                  <i>{{ label.artist }}</i>
-                  <span>{{ label.title }}</span>
+                <div v-for="song in event.songs" :key="song" class="flex flex-col gap-2">
+                  <i>{{ song.artist }}</i>
+                  <span>{{ song.title }}</span>
                 </div>
               </div>
             </div>
@@ -30,18 +30,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type ComputedRef, ref } from 'vue';
+import { computed } from 'vue';
 import type { MenuItem } from 'primevue/menuitem';
 import { useCenturionStore } from '@/stores/modes/centurion.store';
 import type { MixTapeResponse, SongData, SongEvent } from '@/api';
 import { formatDuration } from '@/utils/formatterUtils';
 
-interface TimelineItem {
-  label?: string | Array<SongData>;
+interface TimelineItem extends MenuItem {
+  songs?: Array<SongData>;
   timestamp: string;
-  command: () => Promise<void>;
-  icon?: string;
-  disabled: ComputedRef<boolean>;
 }
 
 const store = useCenturionStore();
@@ -56,33 +53,41 @@ const getTracks = (event: SongEvent): Array<SongData> => {
   return tracks;
 };
 
-const isDisabled = () => {
-  return store.skipping;
-};
+const timelineItems = computed((): Array<TimelineItem> => {
+  const startItem: TimelineItem = {
+    timestamp: formatDuration(0),
+    disabled: store.skipping,
+    command: () => {
+      void store.skipCenturion(0);
+    },
+    label: 'Start',
+  };
 
-const timelineItems = ref(
-  props.tape?.events.reduce((timelineItems, event) => {
-    const timelineItem: TimelineItem = {
-      timestamp: formatDuration(event.timestamp),
-      disabled: computed(() => isDisabled()),
-      command: async () => {
-        await store.skipCenturion(event.timestamp);
-      },
-    };
+  const events =
+    props.tape?.events.reduce((timelineItems, event) => {
+      const timelineItem: TimelineItem = {
+        timestamp: formatDuration(event.timestamp),
+        disabled: store.skipping,
+        command: () => {
+          void store.skipCenturion(event.timestamp);
+        },
+      };
 
-    if (event.type === 'horn') {
-      timelineItem.label = event.data.counter.toString();
-      timelineItem.icon = 'pi pi-volume-up';
-    }
+      if (event.type === 'horn') {
+        timelineItem.label = event.data.counter.toString();
+        timelineItem.icon = 'pi pi-volume-up';
+      }
 
-    if (event.type === 'song') {
-      timelineItem.label = getTracks(event as unknown as SongEvent);
-    }
+      if (event.type === 'song') {
+        timelineItem.songs = getTracks(event as unknown as SongEvent);
+      }
 
-    timelineItems.push(timelineItem);
-    return timelineItems;
-  }, [] as Array<TimelineItem>) ?? [],
-);
+      timelineItems.push(timelineItem);
+      return timelineItems;
+    }, [] as Array<TimelineItem>) ?? [];
+
+  return [startItem, ...events];
+});
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Workaround for Centurion 2 which has problems starting. It works to skip to a certain timestamp, but then you always skip the intro.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_