### PR TITLE
fix(lights-effects): small UX issues in simple effects controller for mobile phones

### DIFF
--- a/src/stores/effects-controller.store.ts
+++ b/src/stores/effects-controller.store.ts
@@ -267,6 +267,14 @@ export const useEffectsControllerStore = defineStore('effectsController', {
     },
     async onEffectButtonPress(button: LightsPredefinedEffectResponse) {
       switch (button.properties.type) {
+        case 'LightsButtonStrobe': {
+          await this.enableStrobe(button.properties.lightsGroupIds);
+          return;
+        }
+      }
+    },
+    async onEffectButtonRelease(button: LightsPredefinedEffectResponse) {
+      switch (button.properties.type) {
         case 'LightsButtonColors': {
           const properties = button.properties;
           this.currentColors = properties.colors;
@@ -302,7 +310,7 @@ export const useEffectsControllerStore = defineStore('effectsController', {
           return;
         }
         case 'LightsButtonStrobe': {
-          await this.enableStrobe(button.properties.lightsGroupIds);
+          await this.disableStrobe(button.properties.lightsGroupIds);
           return;
         }
         case 'LightsButtonSwitch': {
@@ -321,7 +329,7 @@ export const useEffectsControllerStore = defineStore('effectsController', {
         }
       }
     },
-    async onEffectButtonRelease(button: LightsPredefinedEffectResponse) {
+    async onEffectButtonCancel(button: LightsPredefinedEffectResponse) {
       switch (button.properties.type) {
         case 'LightsButtonStrobe': {
           await this.disableStrobe(button.properties.lightsGroupIds);

--- a/src/views/Lights/EffectsControllerSimple.vue
+++ b/src/views/Lights/EffectsControllerSimple.vue
@@ -16,12 +16,21 @@
         :disabled="button.properties.type === 'LightsButtonNull'"
         raised
         :severity="buttonActive(button) ? 'primary' : 'secondary'"
-        @blur="store.onEffectButtonRelease(button)"
-        @mousedown="store.onEffectButtonPress(button)"
-        @mouseleave="store.onEffectButtonRelease(button)"
-        @mouseup="store.onEffectButtonRelease(button)"
-        @touchend="store.onEffectButtonRelease(button)"
-        @touchstart="store.onEffectButtonPress(button)"
+        @pointercancel="
+          () => {
+            store.onEffectButtonCancel(button);
+          }
+        "
+        @pointerdown="
+          () => {
+            store.onEffectButtonPress(button);
+          }
+        "
+        @pointerup="
+          () => {
+            store.onEffectButtonRelease(button);
+          }
+        "
       >
         <EffectControllerButtonContent :button="button" :editing="editing" />
       </Button>

--- a/src/views/Lights/EffectsControllerSimple.vue
+++ b/src/views/Lights/EffectsControllerSimple.vue
@@ -9,49 +9,61 @@
     </template>
 
     <div v-if="!editing" class="grid grid-cols-1 md:grid-cols-8 gap-5">
-      <Button
-        v-for="button in store.buttonEffects"
-        :key="button.buttonId"
-        class="h-14"
-        :disabled="button.properties.type === 'LightsButtonNull'"
-        raised
-        :severity="buttonActive(button) ? 'primary' : 'secondary'"
-        @pointercancel="
-          () => {
-            store.onEffectButtonCancel(button);
-          }
-        "
-        @pointerdown="
-          () => {
-            store.onEffectButtonPress(button);
-          }
-        "
-        @pointerup="
-          () => {
-            store.onEffectButtonRelease(button);
-          }
-        "
+      <div
+        v-for="columnButtons in gridButtons"
+        :key="columnButtons.map((b) => b.buttonId).join(',')"
+        class="flex flex-col gap-5"
       >
-        <EffectControllerButtonContent :button="button" :editing="editing" />
-      </Button>
+        <Button
+          v-for="button in columnButtons"
+          :key="button.buttonId"
+          class="h-14"
+          :disabled="button.properties.type === 'LightsButtonNull'"
+          raised
+          :severity="buttonActive(button) ? 'primary' : 'secondary'"
+          @pointercancel="
+            () => {
+              store.onEffectButtonCancel(button);
+            }
+          "
+          @pointerdown="
+            () => {
+              store.onEffectButtonPress(button);
+            }
+          "
+          @pointerup="
+            () => {
+              store.onEffectButtonRelease(button);
+            }
+          "
+        >
+          <EffectControllerButtonContent :button="button" :editing="editing" />
+        </Button>
+      </div>
     </div>
     <div v-else class="grid grid-cols-1 md:grid-cols-8 gap-5">
-      <Button
-        v-for="button in store.buttonEffects"
-        :key="button.buttonId"
-        class="h-14"
-        raised
-        severity="secondary"
-        variant="outlined"
-        @click="
-          () => {
-            editingButton = button;
-            editingDialogOpen = true;
-          }
-        "
+      <div
+        v-for="columnButtons in gridButtons"
+        :key="columnButtons.map((b) => b.buttonId).join(',')"
+        class="flex flex-col gap-5"
       >
-        <EffectControllerButtonContent :button="button" :editing="editing" />
-      </Button>
+        <Button
+          v-for="button in columnButtons"
+          :key="button.buttonId"
+          class="h-14"
+          raised
+          severity="secondary"
+          variant="outlined"
+          @click="
+            () => {
+              editingButton = button;
+              editingDialogOpen = true;
+            }
+          "
+        >
+          <EffectControllerButtonContent :button="button" :editing="editing" />
+        </Button>
+      </div>
 
       <EffectControllerButtonDialog
         :button="editingButton"
@@ -63,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import BeatVisualizer from '@/components/audio/BeatVisualizer.vue';
 import AppContainer from '@/layout/AppContainer.vue';
 import { useEffectsControllerStore } from '@/stores/effects-controller.store';
@@ -76,6 +88,16 @@ const store = useEffectsControllerStore();
 const editing = ref(false);
 const editingButton = ref<LightsPredefinedEffectResponse>();
 const editingDialogOpen = ref(false);
+
+// Reorganize the buttons so they are grouped column by column instead of as one, giant row
+const gridButtons = computed((): LightsPredefinedEffectResponse[][] => {
+  const rows = Math.ceil(store.buttonEffects.length / 8);
+  const columns: LightsPredefinedEffectResponse[][] = [];
+  for (let i = 0; i < rows; i++) {
+    columns.push(store.buttonEffects.filter((b) => (b.buttonId - 1) % 8 === i));
+  }
+  return columns;
+});
 
 const buttonActive = (button: LightsPredefinedEffectResponse) => {
   if (button.properties.type === 'LightsButtonColors') {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
- Effect buttons are less sensitive on touchscreens, for example when scrolling down. Any strobe buttons are still somewhat sensitive however, because otherwise it is impossible to detect a button press and release.
- On mobile phones, the effect buttons are now rearranged column-by-column instead of row-by-row. This should make it easier to find stuff, because on tablets and larger displays, the buttons are naturally organised in columns as well.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/aurora-backoffice/issues/67.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_