### PR TITLE
feat: add a beat generators overview to see all active beat generators in Aurora Core

### DIFF
--- a/src/components/audio/ArtificialBeatDialog.vue
+++ b/src/components/audio/ArtificialBeatDialog.vue
@@ -9,21 +9,24 @@
     @after-hide="taps = []"
     @show="onDialogShow"
   >
-    <div class="flex flex-column gap-3 justify-content-center">
+    <div class="flex flex-col gap-3 justify-center">
       <div v-if="!currentBpmLoading && currentBpm != null">Current BPM: {{ currentBpm }}</div>
       <div v-else-if="!currentBpmLoading">Artificial Beat Generator is inactive</div>
       <div v-else>
         <Spinner />
       </div>
-      <div class="flex flex-column gap-1">
-        <div class="h-8rem border-1 flex flex-column flex-wrap justify-content-center align-items-center">
-          <p v-if="getBpm() != null">{{ getBpm() }} BPM</p>
-          <p v-else>Tap to set BPM</p>
-          <span>
+      <div class="flex flex-col gap-1 items-center justify-center">
+        <div class="m-2 p-2 min-h-[8rem] w-[16rem] border-1 flex flex-col justify-center items-center">
+          <span v-if="getBpm() != null">{{ getBpm() }} BPM</span>
+          <span v-else>Tap to set BPM</span>
+          <span class="inline-block text-wrap text-center">
+            {{ renderTaps() }}
+            {{ renderTaps() }}
+            {{ renderTaps() }}
             {{ renderTaps() }}
           </span>
         </div>
-        <div class="flex flex-row gap-1 justify-content-center">
+        <div class="flex flex-row gap-1 justify-center">
           <Button label="Tap" @click="taps.push(new Date())" />
           <Button label="Reset" severity="secondary" @click="taps = []" />
         </div>

--- a/src/components/audio/ArtificialBeatDialog.vue
+++ b/src/components/audio/ArtificialBeatDialog.vue
@@ -1,8 +1,9 @@
 <template>
-  <Button @click="visible = true"> Beat Generator </Button>
+  <Button @click="visible = true"> Artificial Beat Generator </Button>
 
   <Dialog
     v-model:visible="visible"
+    class="w-xs sm:w-sm"
     dismissable-mask
     header="Artifical Beat Generator"
     modal
@@ -10,24 +11,35 @@
     @show="onDialogShow"
   >
     <div class="flex flex-col gap-3 justify-center">
+      <Message
+        v-if="infoMessageVisible"
+        class="text-wrap"
+        closable
+        icon="pi pi-info-circle"
+        severity="info"
+        @close="onHelpDialogClose"
+      >
+        With the Artificial Beat Generator, you can set a custom BPM that Aurora will use. This BPM will override all
+        other beat inputs, like manual definitions or the real time beat detector.
+      </Message>
       <div v-if="!currentBpmLoading && currentBpm != null">Current BPM: {{ currentBpm }}</div>
-      <div v-else-if="!currentBpmLoading">Artificial Beat Generator is inactive</div>
+      <div v-else-if="!currentBpmLoading">Artificial Beat Generator is inactive.</div>
       <div v-else>
         <Spinner />
       </div>
       <div class="flex flex-col gap-1 items-center justify-center">
-        <div class="m-2 p-2 min-h-[8rem] w-[16rem] border-1 flex flex-col justify-center items-center">
+        <div
+          class="m-2 p-2 min-h-[8rem] w-full border-1 flex flex-col justify-center items-center select-none"
+          @click="onTap"
+        >
           <span v-if="getBpm() != null">{{ getBpm() }} BPM</span>
           <span v-else>Tap to set BPM</span>
           <span class="inline-block text-wrap text-center">
             {{ renderTaps() }}
-            {{ renderTaps() }}
-            {{ renderTaps() }}
-            {{ renderTaps() }}
           </span>
         </div>
         <div class="flex flex-row gap-1 justify-center">
-          <Button label="Tap" @click="taps.push(new Date())" />
+          <Button label="Tap" @click="onTap" />
           <Button label="Reset" severity="secondary" @click="taps = []" />
         </div>
       </div>
@@ -49,11 +61,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { splitArrayIntoChunks } from '@/utils/arrayUtils';
 import { getArtificialBeatGenerator, startArtificialBeatGenerator, stopArtificialBeatGenerator } from '@/api';
 
+const ARTIFICIAL_BEAT_DIALOG_HELP_CLOSED_SETTING = 'artificial-beat-dialog-help-closed';
+
 const visible = ref<boolean>(false);
+const infoMessageVisible = computed<boolean>(() => {
+  return localStorage.getItem(ARTIFICIAL_BEAT_DIALOG_HELP_CLOSED_SETTING) != 'true';
+});
 const taps = ref<Date[]>([]);
 const currentBpm = ref<number | null>(null);
 const currentBpmLoading = ref<boolean>(false);
@@ -103,6 +120,14 @@ const stopArtificialBeats = async () => {
   await stopArtificialBeatGenerator()
     .then(() => (visible.value = false))
     .finally(() => (stopBpmLoading.value = false));
+};
+
+const onTap = () => {
+  taps.value.push(new Date());
+};
+
+const onHelpDialogClose = () => {
+  localStorage.setItem(ARTIFICIAL_BEAT_DIALOG_HELP_CLOSED_SETTING, 'true');
 };
 </script>
 

--- a/src/components/audio/BeatGenerators.vue
+++ b/src/components/audio/BeatGenerators.vue
@@ -1,0 +1,58 @@
+<template>
+  <AppContainer icon="pi pi-database" title="Active Beat Generators">
+    <template #header>
+      <BeatVisualizer />
+    </template>
+    <div class="flex flex-col gap-3">
+      <Message icon="pi pi-info-circle" severity="info">
+        The table below shows all beat generators that are currently active. The one with the arrow is the generator
+        with precedence: this generator is authoritative and determines the beats through Aurora. It is not possible to
+        change the beat generators here; this window is purely for debugging purposes.
+      </Message>
+      <DataTable
+        v-if="store.generators.length > 0"
+        data-key="id"
+        :loading="loading"
+        :selection="selected"
+        :value="store.generators"
+      >
+        <Column class="w-1">
+          <template #body="slotProps">
+            <i v-if="slotProps.data.hasPrecedence" class="pi pi-arrow-right"></i>
+          </template>
+        </Column>
+        <Column field="name"></Column>
+        <Column>
+          <template #body="slotProps">
+            <BeatVisualizer :beat="slotProps.data.beat" />
+          </template>
+        </Column>
+      </DataTable>
+      <div v-else class="flex justify-center items-center italic mt-8">No beat generators are active.</div>
+    </div>
+  </AppContainer>
+</template>
+
+<script setup lang="ts">
+import { computed, onUnmounted, ref } from 'vue';
+import AppContainer from '@/layout/AppContainer.vue';
+import { useMusicBeatStore } from '@/stores/socket/music-beat.store';
+import BeatVisualizer from '@/components/audio/BeatVisualizer.vue';
+
+const loading = ref<boolean>(true);
+
+const store = useMusicBeatStore();
+void store.initBeatGenerators().then(() => {
+  loading.value = false;
+});
+
+const selected = computed((): string[] => {
+  return store.generators.filter((g) => g.hasPrecedence).map((g) => g.id);
+});
+
+onUnmounted(() => {
+  void store.destroyBeatGenerators();
+});
+</script>
+
+<style scoped></style>

--- a/src/components/audio/BeatGenerators.vue
+++ b/src/components/audio/BeatGenerators.vue
@@ -1,7 +1,10 @@
 <template>
   <AppContainer icon="pi pi-database" title="Active Beat Generators">
     <template #header>
-      <BeatVisualizer />
+      <div class="flex flex-row gap-5 items-center">
+        <ArtificialBeatDialog />
+        <BeatVisualizer />
+      </div>
     </template>
     <div class="flex flex-col gap-3">
       <Message icon="pi pi-info-circle" severity="info">
@@ -38,6 +41,7 @@ import { computed, onUnmounted, ref } from 'vue';
 import AppContainer from '@/layout/AppContainer.vue';
 import { useMusicBeatStore } from '@/stores/socket/music-beat.store';
 import BeatVisualizer from '@/components/audio/BeatVisualizer.vue';
+import ArtificialBeatDialog from '@/components/audio/ArtificialBeatDialog.vue';
 
 const loading = ref<boolean>(true);
 

--- a/src/components/audio/BeatVisualizer.vue
+++ b/src/components/audio/BeatVisualizer.vue
@@ -1,19 +1,35 @@
 <template>
   <div class="flex flex-row gap-1 beat-visualizer">
-    <i :class="store.beat ? 'pi pi-circle' : 'pi pi-circle-fill'" />
-    <i :class="store.beat ? 'pi pi-circle-fill' : 'pi pi-circle'" />
+    <i :class="beat ? 'pi pi-circle' : 'pi pi-circle-fill'" />
+    <i :class="beat ? 'pi pi-circle-fill' : 'pi pi-circle'" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { onUnmounted } from 'vue';
+import { computed, onMounted, onUnmounted } from 'vue';
 import { useMusicBeatStore } from '@/stores/socket/music-beat.store';
 
+const { beat: propsBeat = null } = defineProps<{
+  beat?: boolean | null;
+}>();
+
 const store = useMusicBeatStore();
-store.initBeat();
+
+const beat = computed((): boolean => {
+  if (propsBeat != undefined) return propsBeat;
+  return store.beat;
+});
+
+onMounted(() => {
+  if (propsBeat == undefined) {
+    store.initBeat();
+  }
+});
 
 onUnmounted(() => {
-  store.destroyBeat();
+  if (propsBeat == undefined) {
+    store.destroyBeat();
+  }
 });
 </script>
 

--- a/src/components/audio/BeatVisualizer.vue
+++ b/src/components/audio/BeatVisualizer.vue
@@ -10,10 +10,10 @@ import { onUnmounted } from 'vue';
 import { useMusicBeatStore } from '@/stores/socket/music-beat.store';
 
 const store = useMusicBeatStore();
-store.init();
+store.initBeat();
 
 onUnmounted(() => {
-  store.destroy();
+  store.destroyBeat();
 });
 </script>
 

--- a/src/components/audio/SpotifyCallbackDialog.vue
+++ b/src/components/audio/SpotifyCallbackDialog.vue
@@ -35,7 +35,7 @@ const handleClose = () => {
 };
 
 onMounted(async () => {
-  if (route.path === '/spotify/callback') {
+  if (route.path === '/music/spotify/callback') {
     open.value = true;
     const state = Array.isArray(route.query.state) ? route.query.state.join(',') : route.query.state;
     const code = Array.isArray(route.query.code) ? route.query.code.join(',') : route.query.code;
@@ -47,7 +47,7 @@ onMounted(async () => {
       errorMessage.value = res.error;
     }
     loading.value = false;
-    await router.replace('/spotify');
+    await router.replace('/music');
   }
 });
 </script>

--- a/src/layout/AppContainer.vue
+++ b/src/layout/AppContainer.vue
@@ -1,9 +1,11 @@
 <template>
   <Card>
     <template #title>
-      <div class="flex justify-between mb-4 items-center">
+      <div class="flex flex-wrap gap-2 justify-between mb-4 items-center">
         <div class="uppercase mb-0"><i :class="['pi mr-3', icon]" style="font-size: 1.25rem" />{{ title }}</div>
-        <slot name="header" />
+        <div class="flex-1 text-end flex justify-end items-center">
+          <slot name="header" />
+        </div>
       </div>
     </template>
     <template #content>

--- a/src/layout/AppMenu.vue
+++ b/src/layout/AppMenu.vue
@@ -31,6 +31,7 @@ const model = computed<MenuItem[]>(() => {
   const showSettings = authStore.isInSecurityGroup('serverSettings', 'privileged');
   const showTimedEvents = authStore.isInSecurityGroup('timedEvents', 'privileged');
   const showSpotifySettings = authStore.isInSecurityGroup('spotify', 'privileged');
+  const showBeatSettings = authStore.isInSecurityGroup('beats', 'privileged');
   const showIntegrationUsers = authStore.isInSecurityGroup('integrationUsers', 'privileged');
 
   return [
@@ -76,7 +77,11 @@ const model = computed<MenuItem[]>(() => {
       items: [
         showSettings && { label: 'Server Settings', icon: 'pi pi-fw pi-cog', to: '/settings' },
         showTimedEvents && { label: 'Timed Events', icon: 'pi pi-fw pi-calendar-clock', to: '/timed-events' },
-        showSpotifySettings && { label: 'Spotify Settings', icon: 'pi pi-headphones', to: '/spotify' },
+        (showSpotifySettings || showBeatSettings) && {
+          label: 'Music Settings',
+          icon: 'pi pi-headphones',
+          to: '/music',
+        },
         showIntegrationUsers && { label: 'Integrations', icon: 'pi pi-share-alt', to: '/integrations' },
       ],
     },

--- a/src/stores/socket.store.ts
+++ b/src/stores/socket.store.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia';
 interface SocketStore {
   rootSocket?: Socket;
   backofficeSocket?: Socket;
+  backofficeBeatSocket?: Socket;
 }
 
 export const useSocketStore = defineStore('socket', {
@@ -32,6 +33,25 @@ export const useSocketStore = defineStore('socket', {
         });
       });
       return Promise.all([promise1, promise2]);
+    },
+    async connectBeat() {
+      const beatSocket = io('/backoffice-beat', { path: '/socket.io/' });
+      return new Promise<void>((resolve) => {
+        beatSocket.on('connect', () => {
+          console.info('SocketIO: connected to /backoffice-beat');
+          this.backofficeBeatSocket = beatSocket;
+          resolve();
+        });
+      });
+    },
+    disconnectBeat() {
+      if (!this.backofficeBeatSocket) {
+        console.error('SocketIO: Already disconnected from /backoffice-beat!');
+        return;
+      }
+      this.backofficeBeatSocket.removeAllListeners();
+      this.backofficeBeatSocket.disconnect();
+      this.backofficeBeatSocket = undefined;
     },
   },
 });

--- a/src/stores/socket/music-beat.store.ts
+++ b/src/stores/socket/music-beat.store.ts
@@ -1,36 +1,137 @@
 import { defineStore } from 'pinia';
 import { useSocketStore } from '@/stores/socket.store';
+import { type BeatGeneratorResponse, getAllBeatGenerators } from '@/api';
+
+export interface GeneratorBeatEvent {
+  id: string;
+  name: string;
+}
+
+export interface BeatGeneratorInStore extends BeatGeneratorResponse {
+  beat: boolean;
+}
 
 interface MusicBeatStore {
   beat: boolean;
-  initialized: boolean;
+  initializedBeat: boolean;
+  generators: BeatGeneratorInStore[];
+  initializedGenerators: boolean;
 }
 
 export const useMusicBeatStore = defineStore('music-beat', {
   state: (): MusicBeatStore => ({
     beat: false,
-    initialized: false,
+    initializedBeat: false,
+    generators: [],
+    initializedGenerators: false,
   }),
   getters: {},
   actions: {
-    handleBeat() {
+    handlePrecedenceBeat() {
       this.beat = !this.beat;
     },
-    init() {
-      if (this.initialized) return;
-
-      const store = useSocketStore();
-      if (!store.backofficeSocket) return;
-
-      store.backofficeSocket.on('beat', this.handleBeat.bind(this));
-      this.initialized = true;
+    handleGeneratorBeat([event]: GeneratorBeatEvent[]) {
+      const index = this.generators.findIndex((g) => g.id === event.id);
+      if (index >= 0) {
+        this.generators[index].beat = !this.generators[index].beat;
+      }
     },
-    destroy() {
+    handleGeneratorAdd([event]: BeatGeneratorResponse[]) {
+      if (event.hasPrecedence) {
+        for (const g of this.generators) {
+          g.hasPrecedence = false;
+        }
+      }
+      this.generators.push({
+        id: event.id,
+        name: event.name,
+        hasPrecedence: event.hasPrecedence,
+        beat: false,
+      });
+    },
+    handleGeneratorRemove([event]: BeatGeneratorResponse[]) {
+      const index = this.generators.findIndex((g) => g.id === event.id);
+      if (index >= 0) {
+        const hasPrecedence = this.generators[index].hasPrecedence;
+        this.generators.splice(index, 1);
+        // If this generator had precedence, we need to find which beat generator
+        // is now determining the global beats.
+        if (hasPrecedence) {
+          void this.getAllBeatGenerators();
+        }
+      }
+    },
+    initBeat() {
+      if (this.initializedBeat) return;
+
       const store = useSocketStore();
       if (!store.backofficeSocket) return;
 
-      store.backofficeSocket.removeListener('beat', this.handleBeat.bind(this));
-      this.initialized = false;
+      store.backofficeSocket.on('beat', this.handlePrecedenceBeat.bind(this));
+      this.initializedBeat = true;
+    },
+    destroyBeat() {
+      const store = useSocketStore();
+      if (!store.backofficeSocket) return;
+
+      store.backofficeSocket.removeListener('beat', this.handlePrecedenceBeat.bind(this));
+      this.initializedBeat = false;
+    },
+    async getAllBeatGenerators() {
+      const res = await getAllBeatGenerators();
+
+      // If there are already generators present, synchronize the list in memory
+      // with the fresh list. We do this to preserve the beat state (and not reset it).
+      if (res.response.ok && res.data && this.generators.length > 0) {
+        let notSeenGenerators: BeatGeneratorResponse[] = [...this.generators];
+        res.data.forEach((generator: BeatGeneratorResponse) => {
+          const index = this.generators.findIndex((g) => g.id === generator.id);
+          if (index >= 0) {
+            this.generators[index].id = generator.id;
+            this.generators[index].name = generator.name;
+            this.generators[index].hasPrecedence = generator.hasPrecedence;
+
+            // Remove this generator from the list of all not-seen generators
+            notSeenGenerators = notSeenGenerators.filter((g) => g.id !== generator.id);
+          } else {
+            this.handleGeneratorAdd([generator]);
+          }
+        });
+
+        notSeenGenerators.forEach((g) => {
+          this.handleGeneratorRemove([g]);
+        });
+      } else if (res.response.ok && res.data) {
+        this.generators = res.data.map((g) => ({
+          id: g.id,
+          name: g.name,
+          hasPrecedence: g.hasPrecedence,
+          beat: false,
+        }));
+      }
+    },
+    async initBeatGenerators() {
+      const store = useSocketStore();
+      await store.connectBeat();
+      await this.getAllBeatGenerators();
+
+      if (!store.backofficeBeatSocket) return;
+
+      store.backofficeBeatSocket.on('beat', this.handleGeneratorBeat.bind(this));
+      store.backofficeBeatSocket.on('generator_add', this.handleGeneratorAdd.bind(this));
+      store.backofficeBeatSocket.on('generator_remove', this.handleGeneratorRemove.bind(this));
+      this.initializedGenerators = true;
+    },
+    destroyBeatGenerators() {
+      const store = useSocketStore();
+      if (!store.backofficeBeatSocket) return;
+
+      store.backofficeBeatSocket.removeListener('beat', this.handleGeneratorBeat.bind(this));
+      store.backofficeBeatSocket.removeListener('generator_add', this.handleGeneratorAdd.bind(this));
+      store.backofficeBeatSocket.removeListener('generator_remove', this.handleGeneratorRemove.bind(this));
+      this.initializedGenerators = false;
+
+      store.disconnectBeat();
     },
   },
 });

--- a/src/stores/socket/music-beat.store.ts
+++ b/src/stores/socket/music-beat.store.ts
@@ -30,13 +30,13 @@ export const useMusicBeatStore = defineStore('music-beat', {
     handlePrecedenceBeat() {
       this.beat = !this.beat;
     },
-    handleGeneratorBeat([event]: GeneratorBeatEvent[]) {
+    handleGeneratorBeat(event: GeneratorBeatEvent) {
       const index = this.generators.findIndex((g) => g.id === event.id);
       if (index >= 0) {
         this.generators[index].beat = !this.generators[index].beat;
       }
     },
-    handleGeneratorAdd([event]: BeatGeneratorResponse[]) {
+    handleGeneratorAdd(event: BeatGeneratorResponse) {
       if (event.hasPrecedence) {
         for (const g of this.generators) {
           g.hasPrecedence = false;
@@ -49,7 +49,7 @@ export const useMusicBeatStore = defineStore('music-beat', {
         beat: false,
       });
     },
-    handleGeneratorRemove([event]: BeatGeneratorResponse[]) {
+    handleGeneratorRemove(event: BeatGeneratorResponse) {
       const index = this.generators.findIndex((g) => g.id === event.id);
       if (index >= 0) {
         const hasPrecedence = this.generators[index].hasPrecedence;
@@ -94,12 +94,12 @@ export const useMusicBeatStore = defineStore('music-beat', {
             // Remove this generator from the list of all not-seen generators
             notSeenGenerators = notSeenGenerators.filter((g) => g.id !== generator.id);
           } else {
-            this.handleGeneratorAdd([generator]);
+            this.handleGeneratorAdd(generator);
           }
         });
 
         notSeenGenerators.forEach((g) => {
-          this.handleGeneratorRemove([g]);
+          this.handleGeneratorRemove(g);
         });
       } else if (res.response.ok && res.data) {
         this.generators = res.data.map((g) => ({

--- a/src/views/Base/MusicSettingsView.vue
+++ b/src/views/Base/MusicSettingsView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
     <div class="flex flex-col gap-6">
-      <AppContainer icon="pi-users" title="Spotify Users">
+      <AppContainer v-if="authStore.isInSecurityGroup('spotify', 'privileged')" icon="pi-users" title="Spotify Users">
         <template #header>
           <Button
             as="a"
@@ -39,7 +39,7 @@
       </AppContainer>
       <SpotifyCurrentlyPlaying />
     </div>
-    <BeatGenerators />
+    <BeatGenerators v-if="authStore.isInSecurityGroup('beats', 'privileged')" />
   </div>
   <SpotifyCallbackDialog />
 </template>
@@ -53,7 +53,9 @@ import SpotifyCallbackDialog from '@/components/audio/SpotifyCallbackDialog.vue'
 import SpotifyUserDeleteButton from '@/components/audio/SpotifyUserDeleteButton.vue';
 import SpotifyUserSwitchButton from '@/components/audio/SpotifyUserSwitchButton.vue';
 import BeatGenerators from '@/components/audio/BeatGenerators.vue';
+import { useAuthStore } from '@/stores/auth.store';
 
+const authStore = useAuthStore();
 const store = useSpotifyStore();
 void store.init();
 

--- a/src/views/Base/SpotifySettingsView.vue
+++ b/src/views/Base/SpotifySettingsView.vue
@@ -1,50 +1,65 @@
 <template>
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
-    <AppContainer icon="pi-users" title="Spotify Users">
-      <template #header>
-        <Button
-          as="a"
-          href="/api/spotify/login"
-          icon="pi pi-plus"
-          label="Add user"
-          severity="secondary"
-          variant="outlined"
-        />
-      </template>
-      <div class="flex flex-col gap-3">
-        <DataTable data-key="id" :loading="store.loading" selection="2" show-headers :value="store.spotifyUsers">
-          <Column class="w-1">
-            <template #body="slotProps">
-              <i v-if="slotProps.data.active" class="pi pi-arrow-right"></i>
-            </template>
-          </Column>
-          <Column field="name" header="Name" />
-          <Column>
-            <template #body="slotProps">
-              <div class="flex justify-end gap-2">
-                <SpotifyUserSwitchButton :user="slotProps.data" />
-                <SpotifyUserDeleteButton :user="slotProps.data" />
-              </div>
-            </template>
-          </Column>
-        </DataTable>
-      </div>
-    </AppContainer>
-    <SpotifyCurrentlyPlaying />
+    <div class="flex flex-col gap-6">
+      <AppContainer icon="pi-users" title="Spotify Users">
+        <template #header>
+          <Button
+            as="a"
+            href="/api/spotify/login"
+            icon="pi pi-plus"
+            label="Add user"
+            severity="secondary"
+            variant="outlined"
+          />
+        </template>
+        <div class="flex flex-col gap-3">
+          <DataTable
+            data-key="id"
+            :loading="store.loading"
+            :selection="selection"
+            show-headers
+            :value="store.spotifyUsers"
+          >
+            <Column class="w-1">
+              <template #body="slotProps">
+                <i v-if="slotProps.data.active" class="pi pi-arrow-right"></i>
+              </template>
+            </Column>
+            <Column field="name" header="Name" />
+            <Column>
+              <template #body="slotProps">
+                <div class="flex justify-end gap-2">
+                  <SpotifyUserSwitchButton :user="slotProps.data" />
+                  <SpotifyUserDeleteButton :user="slotProps.data" />
+                </div>
+              </template>
+            </Column>
+          </DataTable>
+        </div>
+      </AppContainer>
+      <SpotifyCurrentlyPlaying />
+    </div>
+    <BeatGenerators />
   </div>
   <SpotifyCallbackDialog />
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import AppContainer from '@/layout/AppContainer.vue';
 import SpotifyCurrentlyPlaying from '@/components/audio/SpotifyCurrentlyPlaying.vue';
 import { useSpotifyStore } from '@/stores/spotify.store';
 import SpotifyCallbackDialog from '@/components/audio/SpotifyCallbackDialog.vue';
 import SpotifyUserDeleteButton from '@/components/audio/SpotifyUserDeleteButton.vue';
 import SpotifyUserSwitchButton from '@/components/audio/SpotifyUserSwitchButton.vue';
+import BeatGenerators from '@/components/audio/BeatGenerators.vue';
 
 const store = useSpotifyStore();
 void store.init();
+
+const selection = computed(() => {
+  return store.spotifyUsers.filter((s) => s.active).map((s) => s.id);
+});
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
This PR adds a table to Aurora Backoffice to view and debug all active beat generators in Aurora Core. Furthermore, the layout of the Artificial Beat Dialog has been fixed.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Depends on https://github.com/GEWIS/aurora-core/pull/103.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_